### PR TITLE
Fixes for JSON api formatted data

### DIFF
--- a/Resources/skeleton/controller/actions/delete.php.twig
+++ b/Resources/skeleton/controller/actions/delete.php.twig
@@ -44,7 +44,8 @@
 {% block method_body %}
         ${{ entity|lowerfirst }} = $this->getOr404($id);
         try {
-            $this->get{{ entity }}Handler()->delete{{ entity }}(${{ entity|lowerfirst }});
+            $this->get{{ entity }}Handler()
+                ->delete{{ entity }}(${{ entity|lowerfirst }});
 
             return new Response('', Codes::HTTP_NO_CONTENT);
         } catch (\Exception $exception) {

--- a/Resources/skeleton/controller/actions/getAll.php.twig
+++ b/Resources/skeleton/controller/actions/getAll.php.twig
@@ -61,12 +61,13 @@
         $orderBy = $paramFetcher->get('order_by');
         $criteria = !is_null($paramFetcher->get('filters')) ? $paramFetcher->get('filters') : array();
 
-        $result = $this->get{{ entity }}Handler()->find{{ entity|pluralize }}By(
-            $criteria,
-            $orderBy,
-            $limit,
-            $offset
-        );
+        $result = $this->get{{ entity }}Handler()
+            ->find{{ entity|pluralize }}By(
+                $criteria,
+                $orderBy,
+                $limit,
+                $offset
+            );
         //If there are no matches return an empty array
         $answer{{ resource ? "['" ~ entity|lowerfirst|pluralize ~  "']" }} =
             $result ? $result : new ArrayCollection([]);

--- a/Resources/skeleton/controller/actions/getAll.php.twig
+++ b/Resources/skeleton/controller/actions/getAll.php.twig
@@ -61,19 +61,17 @@
         $orderBy = $paramFetcher->get('order_by');
         $criteria = !is_null($paramFetcher->get('filters')) ? $paramFetcher->get('filters') : array();
 
+        $result = $this->get{{ entity }}Handler()->find{{ entity|pluralize }}By(
+            $criteria,
+            $orderBy,
+            $limit,
+            $offset
+        );
+        //If there are no matches return an empty array
         $answer{{ resource ? "['" ~ entity|lowerfirst|pluralize ~  "']" }} =
-            $this->get{{ entity }}Handler()->find{{ entity|pluralize }}By(
-                $criteria,
-                $orderBy,
-                $limit,
-                $offset
-            );
+            $result ? $result : new ArrayCollection([]);
 
-        if ($answer{{ resource ? "['" ~ entity|lowerfirst|pluralize ~  "']" }}) {
-            return $answer;
-        }
-
-        return new ArrayCollection([]);
+        return $answer;
 {% endblock method_body %}
 {% block method_return '' %}
     }

--- a/Resources/skeleton/controller/actions/getById.php.twig
+++ b/Resources/skeleton/controller/actions/getById.php.twig
@@ -9,7 +9,12 @@
      *   description = "Get a {{ entity }}.",
      *   resource = true,
      *   requirements={
-     *     {"name"="{{ entity_identifier }}", "dataType"="{{ entity_identifier_type }}", "requirement"="{{ requirement_regex }}", "description"="{{ entity }} identifier."}
+     *     {
+     *        "name"="{{ entity_identifier }}",
+     *        "dataType"="{{ entity_identifier_type }}",
+     *        "requirement"="{{ requirement_regex }}",
+     *        "description"="{{ entity }} identifier."
+     *     }
      *   },
      *   output="{{ namespace }}\Entity\{{ entity_namespace }}{{ entity }}",
      *   statusCodes={

--- a/Resources/skeleton/controller/actions/getOr404.php.twig
+++ b/Resources/skeleton/controller/actions/getOr404.php.twig
@@ -12,11 +12,12 @@
 {% endblock method_definition %}
     {
 {% block method_body %}
-        if (!($entity = $this->get{{ entity }}Handler()->find{{ entity }}By(['{{ entity_identifier }}' => $id]))) {
-            throw new NotFoundHttpException(sprintf('The resource \'%s\' was not found.',$id));
+        $entity = $this->get{{ entity }}Handler()
+            ->find{{ entity }}By(['{{ entity_identifier }}' => $id]);
+        if (!$entity) {
+            throw new NotFoundHttpException(sprintf('The resource \'%s\' was not found.', $id));
         }
 
         return $entity;
 {% endblock method_body %}
     }
-

--- a/Resources/skeleton/controller/actions/getPostData.php.twig
+++ b/Resources/skeleton/controller/actions/getPostData.php.twig
@@ -1,0 +1,16 @@
+   /**
+{% block phpdoc_method_header %}
+    * Parse the request for the form data
+    *
+    * @param Request $request
+    * @return array
+{% endblock phpdoc_method_header %}
+     */
+{% block method_definition %}
+    protected function getPostData(Request $request)
+{% endblock method_definition %}
+    {
+{% block method_body %}
+        return $request->request->get({{ resource ? "'" ~ entity|lowerfirst ~  "'" }}, array());
+{% endblock method_body %}
+    }

--- a/Resources/skeleton/controller/actions/patch.php.twig
+++ b/Resources/skeleton/controller/actions/patch.php.twig
@@ -39,7 +39,7 @@
 {% endblock method_definition %}
     {
 {% block method_body %}
-        $answer{{ resource ? "['" ~ entity|lowerfirst ~  "']" }} = $this->get{{ entity }}Handler()->patch($this->getOr404($id), $request->request->all());
+        $answer{{ resource ? "['" ~ entity|lowerfirst ~  "']" }} = $this->get{{ entity }}Handler()->patch($this->getOr404($id), $this->getPostData($request));
 
         return $answer;
 {% endblock method_body %}

--- a/Resources/skeleton/controller/actions/patch.php.twig
+++ b/Resources/skeleton/controller/actions/patch.php.twig
@@ -11,7 +11,12 @@
      *   input="{{ form_type|replace({'.php': ''}) }}",
      *   output="{{ namespace }}\Entity\{{ entity_namespace }}{{ entity }}",
      *   requirements={
-     *     {"name"="{{ entity_identifier }}", "dataType"="{{ entity_identifier_type }}", "requirement"="{{ requirement_regex }}", "description"="{{ entity }} identifier."}
+     *     {
+     *         "name"="{{ entity_identifier }}",
+     *         "dataType"="{{ entity_identifier_type }}",
+     *         "requirement"="{{ requirement_regex }}",
+     *         "description"="{{ entity }} identifier."
+     *     }
      *   },
      *   statusCodes={
      *     200 = "Updated {{ entity }}.",
@@ -39,7 +44,11 @@
 {% endblock method_definition %}
     {
 {% block method_body %}
-        $answer{{ resource ? "['" ~ entity|lowerfirst ~  "']" }} = $this->get{{ entity }}Handler()->patch($this->getOr404($id), $this->getPostData($request));
+        $answer{{ resource ? "['" ~ entity|lowerfirst ~  "']" }} =
+            $this->get{{ entity }}Handler()->patch(
+                $this->getOr404($id),
+                $this->getPostData($request)
+            );
 
         return $answer;
 {% endblock method_body %}

--- a/Resources/skeleton/controller/actions/post.php.twig
+++ b/Resources/skeleton/controller/actions/post.php.twig
@@ -35,7 +35,7 @@
     {
 {% block method_body %}
         try {
-            $new  =  $this->get{{ entity }}Handler()->post($request->request->all());
+            $new  =  $this->get{{ entity }}Handler()->post($this->getPostData($request));
             $answer{{ resource ? "['" ~ entity|lowerfirst ~  "']" }} = $new;
 
             return $answer;

--- a/Resources/skeleton/controller/actions/put.php.twig
+++ b/Resources/skeleton/controller/actions/put.php.twig
@@ -37,11 +37,18 @@
     {
 {% block method_body %}
         try {
-            if (${{ entity|lowerfirst }} = $this->get{{ entity }}Handler()->find{{ entity }}By(['{{ entity_identifier }}'=> $id])) {
-                $answer{{ resource ? "['" ~ entity|lowerfirst ~  "']" }}= $this->get{{ entity }}Handler()->put(${{ entity|lowerfirst }}, $this->getPostData($request));
+            ${{ entity|lowerfirst }} = $this->get{{ entity }}Handler()
+                ->find{{ entity }}By(['{{ entity_identifier }}'=> $id]);
+            if (${{ entity|lowerfirst }}) {
+                $answer{{ resource ? "['" ~ entity|lowerfirst ~  "']" }} =
+                    $this->get{{ entity }}Handler()->put(
+                        ${{ entity|lowerfirst }},
+                        $this->getPostData($request)
+                    );
                 $code = Codes::HTTP_OK;
             } else {
-                $answer{{ resource ? "['" ~ entity|lowerfirst ~  "']" }} = $this->get{{ entity }}Handler()->post($this->getPostData($request));
+                $answer{{ resource ? "['" ~ entity|lowerfirst ~  "']" }} =
+                    $this->get{{ entity }}Handler()->post($this->getPostData($request));
                 $code = Codes::HTTP_CREATED;
             }
         } catch (InvalidFormException $exception) {

--- a/Resources/skeleton/controller/actions/put.php.twig
+++ b/Resources/skeleton/controller/actions/put.php.twig
@@ -38,10 +38,10 @@
 {% block method_body %}
         try {
             if (${{ entity|lowerfirst }} = $this->get{{ entity }}Handler()->find{{ entity }}By(['{{ entity_identifier }}'=> $id])) {
-                $answer{{ resource ? "['" ~ entity|lowerfirst ~  "']" }}= $this->get{{ entity }}Handler()->put(${{ entity|lowerfirst }}, $request->request->all());
+                $answer{{ resource ? "['" ~ entity|lowerfirst ~  "']" }}= $this->get{{ entity }}Handler()->put(${{ entity|lowerfirst }}, $this->getPostData($request));
                 $code = Codes::HTTP_OK;
             } else {
-                $answer{{ resource ? "['" ~ entity|lowerfirst ~  "']" }} = $this->get{{ entity }}Handler()->post($request->request->all());
+                $answer{{ resource ? "['" ~ entity|lowerfirst ~  "']" }} = $this->get{{ entity }}Handler()->post($this->getPostData($request));
                 $code = Codes::HTTP_CREATED;
             }
         } catch (InvalidFormException $exception) {

--- a/Resources/skeleton/controller/controller.php.twig
+++ b/Resources/skeleton/controller/controller.php.twig
@@ -59,5 +59,7 @@ class {{ entity }}Controller extends FOSRestController
 
     {%- include 'controller/actions/getOr404.php.twig' %}
 
+    {%- include 'controller/actions/getPostData.php.twig' %}
+
     {%- include 'controller/actions/extra.php.twig' %}{% endblock class_body %}
 }


### PR DESCRIPTION
Two changes:
1. When there are no matching entities return name: [] instead of just []
2. Submitted data is keyed by the resource name

I see there is a command flag --resource which I think is for the JSON api stuff, but I didn't see how to scope these templates to that flag.  Is that enabled?