### PR TITLE
Correctly detect relationship type for form generation

### DIFF
--- a/Generator/FormGenerator.php
+++ b/Generator/FormGenerator.php
@@ -49,6 +49,7 @@ class FormGenerator extends Generator
                 'namespace'             => $bundle->getNamespace(),
                 'entity_namespace'      => implode('\\', $parts),
                 'entity_class'          => $entityClass,
+                'entity'                => $entity,
                 'bundle'                => $bundle->getName(),
                 'rest_support'          => $options->get('rest-support'),
                 'form_class'            => $this->generatedName,

--- a/Generator/Generator.php
+++ b/Generator/Generator.php
@@ -134,12 +134,12 @@ abstract class Generator implements GeneratorInterface
                 ClassMetadataInfo::MANY_TO_MANY,
             );
             if (in_array($relation['type'], $multiTypes)) {
-                $fields[$fieldName]['realtedType'] = 'many';
+                $fields[$fieldName]['relatedType'] = 'many';
             } else {
-                $fields[$fieldName]['realtedType'] = 'single';
+                $fields[$fieldName]['relatedType'] = 'single';
             }
 
-            $fields[$fieldName]['relatedEntityShrotcut'] =
+            $fields[$fieldName]['relatedEntityShortcut'] =
                 $this->getEntityBundleShortcut($fields[$fieldName]['targetEntity']);
         }
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -11,7 +11,7 @@
         </service>
         <service id="tdn.type.tdn_many_reated" class="Tdn\SfProjectGeneratorBundle\Form\Type\ManyRelatedType">
             <argument type="service" id="doctrine.orm.entity_manager"/>
-            <tag name="form.type" alias="dn_many_reated" />
+            <tag name="form.type" alias="tdn_many_related" />
         </service>
         <service id="tdn.type.tdn_single_related" class="Tdn\SfProjectGeneratorBundle\Form\Type\SingleRelatedType">
             <argument type="service" id="doctrine.orm.entity_manager"/>

--- a/Resources/skeleton/form/FormType.php.twig
+++ b/Resources/skeleton/form/FormType.php.twig
@@ -26,9 +26,9 @@ class {{ entity_class }}Type extends AbstractType
 
 {% endif %}
 {% if rest_support and field.fieldName in associations|keys %}
-            ->add('{{ field.fieldName }}', 'tdn_{{ field.realtedType }}_related', [
+            ->add('{{ field.fieldName }}', 'tdn_{{ field.relatedType }}_related', [
                 'required' => false,
-                'entityName' => "{{ field.relatedEntityShrotcut }}"
+                'entityName' => "{{ field.relatedEntityShortcut }}"
             ])
 {% else %}
 {% if field.nullable or field.type == 'boolean' %}

--- a/Resources/skeleton/form/FormType.php.twig
+++ b/Resources/skeleton/form/FormType.php.twig
@@ -26,10 +26,10 @@ class {{ entity_class }}Type extends AbstractType
 
 {% endif %}
 {% if rest_support and field.fieldName in associations|keys %}
-    ->add('{{ field.fieldName }}', 'tdn_single_related', [
-        'required' => false,
-        'entityName' => "{{ field.targetEntity|addslashes }}"
-    ])
+            ->add('{{ field.fieldName }}', 'tdn_{{ field.realtedType }}_related', [
+                'required' => false,
+                'entityName' => "{{ field.relatedEntityShrotcut }}"
+            ])
 {% else %}
             ->add('{{ field.fieldName }}')
 {% endif %}
@@ -53,11 +53,11 @@ class {{ entity_class }}Type extends AbstractType
      */
     public function getName()
     {
-        {% if rest_support %}
-            return '{{ rest_form_type_name }}';
-        {% else %}
-            return '{{ form_type_name }}_form_type';
-        {% endif %}
+{% if rest_support %}
+        return '{{ rest_form_type_name }}';
+{% else %}
+        return '{{ form_type_name }}_form_type';
+{% endif %}
     }
 {% endblock class_body %}
 }

--- a/Resources/skeleton/form/FormType.php.twig
+++ b/Resources/skeleton/form/FormType.php.twig
@@ -31,7 +31,11 @@ class {{ entity_class }}Type extends AbstractType
                 'entityName' => "{{ field.relatedEntityShrotcut }}"
             ])
 {% else %}
+{% if field.nullable or field.type == 'boolean' %}
+            ->add('{{ field.fieldName }}', null, ['required' => false])
+{% else %}
             ->add('{{ field.fieldName }}')
+{% endif %}
 {% endif %}
 {%- endfor %}
         ;


### PR DESCRIPTION
Also added required => false flag to field types that are nullable or boolean so HTML5 validator doesn't jump in.

Oh and fixed a massive typo in the service definition.